### PR TITLE
Handle chained assignments

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -12,7 +12,7 @@ check-types:
     uv -q run mypy .
 
 test *args:
-    @.venv/bin/pytest -- {{ args }}
+    @.venv/bin/pytest {{ args }}
 
 publish-package:
     rm -rf dist/*

--- a/auto_typing_final/transform.py
+++ b/auto_typing_final/transform.py
@@ -76,21 +76,24 @@ def _make_operation_from_assignments_to_one_name(nodes: list[SgNode]) -> Operati
 
         if node.kind() == "assignment":
             match tuple((child.kind(), child) for child in node.children()):
-                case (("identifier", left), ("=", _), (_, right)):
+                case (
+                    ("identifier", left),
+                    ("=", _),
+                    (_, right),
+                ) if right.kind() != "assignment" and not _is_inside_assignment(node):
                     value_assignments.append(
-                        OtherDefinition(node)
-                        if right.kind() == "assignment" or _is_inside_assignment(node)
-                        else AssignmentWithoutAnnotation(node=node, left=left.text(), right=right.text())
+                        AssignmentWithoutAnnotation(node=node, left=left.text(), right=right.text())
                     )
-                case (("identifier", left), (":", _), ("type", annotation), ("=", _), (_, right)):
-                    if right.kind() == "assignment" or _is_inside_assignment(node):
-                        value_assignments.append(OtherDefinition(node))
-                    else:
-                        value_assignments.append(
-                            AssignmentWithAnnotation(
-                                node=node, left=left.text(), annotation=annotation, right=right.text()
-                            )
-                        )
+                case (
+                    ("identifier", left),
+                    (":", _),
+                    ("type", annotation),
+                    ("=", _),
+                    (_, right),
+                ) if right.kind() != "assignment" and not _is_inside_assignment(node):
+                    value_assignments.append(
+                        AssignmentWithAnnotation(node=node, left=left.text(), annotation=annotation, right=right.text())
+                    )
                 case _:
                     value_assignments.append(OtherDefinition(node))
         else:

--- a/auto_typing_final/transform.py
+++ b/auto_typing_final/transform.py
@@ -70,8 +70,8 @@ def _make_definition_from_definition_node(node: SgNode) -> Definition:
         case (
             ("identifier", left),
             ("=", _),
-            (_, right),
-        ) if right.kind() != "assignment" and not ((parent := node.parent()) and parent.kind() == "assignment"):
+            (right_kind, right),
+        ) if right_kind != "assignment" and not ((parent := node.parent()) and parent.kind() == "assignment"):
             return EditableAssignmentWithoutAnnotation(node=node, left=left.text(), right=right.text())
 
         case (
@@ -79,8 +79,8 @@ def _make_definition_from_definition_node(node: SgNode) -> Definition:
             (":", _),
             ("type", annotation),
             ("=", _),
-            (_, right),
-        ) if right.kind() != "assignment" and not ((parent := node.parent()) and parent.kind() == "assignment"):
+            (right_kind, right),
+        ) if right_kind != "assignment" and not ((parent := node.parent()) and parent.kind() == "assignment"):
             return EditableAssignmentWithAnnotation(
                 node=node, left=left.text(), annotation=annotation, right=right.text()
             )

--- a/auto_typing_final/transform.py
+++ b/auto_typing_final/transform.py
@@ -27,7 +27,7 @@ IMPORT_STYLES_TO_IMPORT_CONFIGS: dict[ImportStyle, ImportConfig] = {
 
 
 @dataclass
-class EditableAssignmentWithoutAnnotation:  # TODO: Rename to EditableAssignment
+class EditableAssignmentWithoutAnnotation:
     node: SgNode
     left: str
     right: str

--- a/auto_typing_final/transform.py
+++ b/auto_typing_final/transform.py
@@ -66,7 +66,6 @@ def _is_inside_assignment(node: SgNode) -> bool:
     return bool((parent := node.parent()) and parent.kind() == "assignment")
 
 
-
 def _make_operation_from_assignments_to_one_name(nodes: list[SgNode]) -> Operation:
     value_assignments: Final[list[Definition]] = []
     has_node_inside_loop = False
@@ -78,12 +77,11 @@ def _make_operation_from_assignments_to_one_name(nodes: list[SgNode]) -> Operati
         if node.kind() == "assignment":
             match tuple((child.kind(), child) for child in node.children()):
                 case (("identifier", left), ("=", _), (_, right)):
-                    if right.kind() == "assignment" or _is_inside_assignment(node):
-                        value_assignments.append(OtherDefinition(node))
-                    else:
-                        value_assignments.append(
-                            AssignmentWithoutAnnotation(node=node, left=left.text(), right=right.text())
-                        )
+                    value_assignments.append(
+                        OtherDefinition(node)
+                        if right.kind() == "assignment" or _is_inside_assignment(node)
+                        else AssignmentWithoutAnnotation(node=node, left=left.text(), right=right.text())
+                    )
                 case (("identifier", left), (":", _), ("type", annotation), ("=", _), (_, right)):
                     if right.kind() == "assignment" or _is_inside_assignment(node):
                         value_assignments.append(OtherDefinition(node))

--- a/auto_typing_final/transform.py
+++ b/auto_typing_final/transform.py
@@ -73,7 +73,6 @@ def _make_definition_from_definition_node(node: SgNode) -> Definition:
             (right_kind, right),
         ) if right_kind != "assignment" and not ((parent := node.parent()) and parent.kind() == "assignment"):
             return EditableAssignmentWithoutAnnotation(node=node, left=left.text(), right=right.text())
-
         case (
             ("identifier", left),
             (":", _),
@@ -150,8 +149,6 @@ def _strip_identifier_from_type_annotation(  # noqa: C901, PLR0911
 def _make_changed_text_from_operation(  # noqa: C901
     operation: Operation, final_value: str, imports_result: ImportsResult, identifier_name: str
 ) -> Iterable[tuple[SgNode, str]]:
-    # print(operation)
-    # breakpoint()
     match operation:
         case AddFinal(assignment):
             match assignment:
@@ -201,8 +198,7 @@ def make_replacements(root: SgNode, import_config: ImportConfig) -> MakeReplacem
     replacements: Final = []
     has_added_final = False
     imports_result: Final = find_imports_of_identifier_in_scope(root, module_name="typing", identifier_name="Final")
-    # t = find_all_definitions_in_functions(root)
-    # breakpoint()
+
     for current_definitions in find_all_definitions_in_functions(root):
         operation = _make_operation_from_definitions_of_one_name(current_definitions)
         edits = [

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -30,12 +30,16 @@ from auto_typing_final.transform import IMPORT_STYLES_TO_IMPORT_CONFIGS, ImportC
         ("(a, b) = t()", "(a, b) = t()"),
         ("[a, b] = t()", "[a, b] = t()"),
         ("[a] = t()", "[a] = t()"),
+        ("a = b = 1", "a = b = 1"),
+        ("a = b = c = 1", "a = b = c = 1"),
+        ("a = (b := 1)", "a: {} = (b := 1)"),
         # Remove annotation
         ("a = 1\na: {}[int] = 2", "a = 1\na: int = 2"),
         ("a = 1\na: {} = 2", "a = 1\na = 2"),
         ("a: int = 1\na: {}[int] = 2", "a: int = 1\na: int = 2"),
         ("a: int = 1\na: {} = 2", "a: int = 1\na = 2"),
         ("a: {} = 1\na: {} = 2\na = 3\na: int = 4", "a = 1\na = 2\na = 3\na: int = 4"),
+        ("a: {} = b = 1", "a: {} = b = 1"),
         # Both
         ("a = 1\nb = 2\nb: {}[int] = 3", "a: {} = 1\nb = 2\nb: int = 3"),
     ],


### PR DESCRIPTION
Now `a = b = 1` does not convert to `a: Final = b = 1`—which is invalid syntax.