### PR TITLE
Avoid reformatting code when no change is necessary

### DIFF
--- a/auto_typing_final/transform.py
+++ b/auto_typing_final/transform.py
@@ -167,7 +167,7 @@ def _make_changed_text_from_operation(  # noqa: C901
             for assignment in assignments:
                 match assignment:
                     case EditableAssignmentWithoutAnnotation(node, left, right):
-                        yield node, f"{left} = {right}"
+                        yield node, node.text()
                     case EditableAssignmentWithAnnotation(node, left, annotation, right):
                         match _strip_identifier_from_type_annotation(annotation, imports_result, identifier_name):
                             case _, "":

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -36,6 +36,8 @@ from auto_typing_final.transform import IMPORT_STYLES_TO_IMPORT_CONFIGS, ImportC
         # Remove annotation
         ("a = 1\na: {}[int] = 2", "a = 1\na: int = 2"),
         ("a = 1\na: {} = 2", "a = 1\na = 2"),
+        ("a = 1\na: {}=2", "a = 1\na = 2"),
+        ("a = 1\na =2", "a = 1\na =2"),
         ("a: int = 1\na: {}[int] = 2", "a: int = 1\na: int = 2"),
         ("a: int = 1\na: {} = 2", "a: int = 1\na = 2"),
         ("a: {} = 1\na: {} = 2\na = 3\na: int = 4", "a = 1\na = 2\na = 3\na: int = 4"),


### PR DESCRIPTION
Respect whitespace between left and right parts of assignments without annotation that don't require adding Final