### PR TITLE
Use PEP 735 dependency-groups.dev for dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "auto-typing-final"
 description = "Automagically set typing.Final inside your functions"
 authors = [{ name = "Lev Vereshchagin", email = "mail@vrslev.com" }]
-dependencies = ["ast-grep-py==0.27.3", "pygls==1.3.1"]
+dependencies = ["ast-grep-py==0.28.1", "pygls==1.3.1"]
 requires-python = ">=3.10"
 readme = "README.md"
 license = { text = "MIT" }
@@ -22,13 +22,8 @@ Repository = "https://github.com/vrslev/auto-typing-final"
 auto-typing-final = "auto_typing_final.main:main"
 auto-typing-final-lsp-server = "auto_typing_final.lsp:main"
 
-[tool.uv]
-dev-dependencies = [
-    "mypy==1.11.2",
-    "pytest==8.3.3",
-    "pytest-cov==5.0.0",
-    "ruff==0.6.8",
-]
+[dependency-groups]
+dev = ["mypy==1.13.0", "pytest==8.3.3", "pytest-cov==5.0.0", "ruff==0.7.1"]
 
 [build-system]
 requires = ["hatchling", "hatch-vcs"]


### PR DESCRIPTION
uv recently released new version that supports now standardized `[dependency-groups]` table. See [uv 0.4.27](https://github.com/astral-sh/uv/releases/tag/0.4.27) and [PEP 735](https://peps.python.org/pep-0735/)